### PR TITLE
chore: typescript import should be specific not global

### DIFF
--- a/StackResourceWatcher.d.ts
+++ b/StackResourceWatcher.d.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk'
+import * as AWS from 'aws-sdk'
 
 type Options = {
   interval: number

--- a/deployCloudFormationStack.d.ts
+++ b/deployCloudFormationStack.d.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk'
+import { CloudFormation } from 'aws-sdk'
 import { Readable } from 'stream'
 
 type Parameter = {
@@ -19,7 +19,7 @@ interface StackResourceWatcher {
 }
 
 export default function deployCloudFormationStack(options: {
-  cloudformation?: AWS.CloudFormation | null | undefined
+  cloudformation?: CloudFormation | null | undefined
   watchResources?: boolean | null | undefined
   region?: string | null | undefined
   approve?: boolean | null | undefined

--- a/deployCloudFormationStacks.d.ts
+++ b/deployCloudFormationStacks.d.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk'
+import { CloudFormation } from 'aws-sdk'
 import { Readable } from 'stream'
 
 type Parameter = {
@@ -13,7 +13,7 @@ type Tag = {
 }
 
 export default function deployCloudFormationStacks(options: {
-  cloudformation?: AWS.CloudFormation | null | undefined
+  cloudformation?: CloudFormation | null | undefined
   watchResources?: boolean | null | undefined
   stacks: Array<{
     region?: string | null | undefined

--- a/getCurrentStackEvents.d.ts
+++ b/getCurrentStackEvents.d.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk'
+import { CloudFormation } from 'aws-sdk'
 
 type StackEvent = {
   StackId: string
@@ -14,6 +14,6 @@ type StackEvent = {
 }
 
 export default function getCurrentStackEvents(options: {
-  cloudformation?: AWS.CloudFormation | null | undefined
+  cloudformation?: CloudFormation | null | undefined
   StackName: string
 }): AsyncIterable<StackEvent>

--- a/getStackOutputs.d.ts
+++ b/getStackOutputs.d.ts
@@ -1,7 +1,7 @@
-import AWS from 'aws-sdk'
+import { CloudFormation } from 'aws-sdk'
 
 export default function getStackOutputs(options: {
-  cloudformation?: AWS.CloudFormation | null | undefined
+  cloudformation?: CloudFormation | null | undefined
   StackName: string
   region?: string | null | undefined
 }): Promise<Record<string, string>>

--- a/getStackResources.d.ts
+++ b/getStackResources.d.ts
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk'
+import { CloudFormation } from 'aws-sdk'
 
 type StackResource = {
   LogicalResourceId: string
@@ -11,6 +11,6 @@ type StackResource = {
 }
 
 export default function getStackResources(options: {
-  cloudformation?: AWS.CloudFormation | null | undefined
+  cloudformation?: CloudFormation | null | undefined
   StackName: string
 }): Promise<Array<StackResource>>

--- a/securityGroups.d.ts
+++ b/securityGroups.d.ts
@@ -1,6 +1,6 @@
 // @flow
 
-import AWS from 'aws-sdk'
+import { EC2 } from "aws-sdk";
 
 export function getSecurityGroupId(options: {
   securityGroupName: string
@@ -13,6 +13,6 @@ export function upsertSecurityGroup(options: {
   securityGroupName: string
   securityGroupDescription?: string | null | undefined
   vpcId: string
-  ec2?: AWS.EC2 | null | undefined
+  ec2?: EC2 | null | undefined
   region?: string | null | undefined
 }): Promise<{ securityGroupId: string }>

--- a/watchStackResources.d.ts
+++ b/watchStackResources.d.ts
@@ -1,8 +1,8 @@
-import AWS from 'aws-sdk'
+import { CloudFormation } from 'aws-sdk'
 
 export default function watchStackResources(options: {
   delay?: number | null | undefined
-  cloudformation?: AWS.CloudFormation | null | undefined
+  cloudformation?: CloudFormation | null | undefined
   StackName?: string | null | undefined
   StackNames?: string[] | null | undefined
   whilePending?: Promise<any> | null | undefined


### PR DESCRIPTION
aws-sdk throwing "no default export" since current standards are to import specific libraries not the entire package